### PR TITLE
Add data-pagefind-ignore attribute to Google Maps link

### DIFF
--- a/src/_includes/layouts/photo.njk
+++ b/src/_includes/layouts/photo.njk
@@ -40,7 +40,7 @@
             <div class='list-horizontal horizontal-gap--2'>
               <dt class='data-key' data-pagefind-ignore>Location:</dt>
               <dd class='data-value'>
-                <span>{% if photo.localized != null %}{{ photo.localized }}, {% endif %}{{ photo.country }}</span> <a href="https://www.google.com/maps?q={{ photo.gps.lat }},{{ photo.gps.lon }}" rel="noopener noreferrer" target="_blank" class="view-map-link">(view in Google Maps)</a>
+                <span>{% if photo.localized != null %}{{ photo.localized }}, {% endif %}{{ photo.country }}</span> <a href="https://www.google.com/maps?q={{ photo.gps.lat }},{{ photo.gps.lon }}" rel="noopener noreferrer" target="_blank" class="view-map-link" data-pagefind-ignore>(view in Google Maps)</a>
               </dd>
             </div>
           {% endif %}


### PR DESCRIPTION
Noticed the search also included the Google Maps link.

This intends to remove that and not be indexed.